### PR TITLE
feat: projectHomes + healthchecks + telescope.find via fd

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture
 
+This file describes the codebase. If you maintain a fork, see **Upstream pull requests** in [README.md](README.md) before contributing changes back to [CWood-sdf/spaceport.nvim](https://github.com/CWood-sdf/spaceport.nvim).
+
 ## High Level Overview
 
 Spaceport is composed of two seperate components: the project tracker and a powerful rendering engine.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,5 @@
 # Architecture
 
-This file describes the codebase. If you maintain a fork, see **Upstream pull requests** in [README.md](README.md) before contributing changes back to [CWood-sdf/spaceport.nvim](https://github.com/CWood-sdf/spaceport.nvim).
-
 ## High Level Overview
 
 Spaceport is composed of two seperate components: the project tracker and a powerful rendering engine.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The "blazingly fastest" way to get to your projects
 
+**Fork:** [`mhgit/spaceport-sdf`](https://github.com/mhgit/spaceport-sdf) · **Upstream:** [`CWood-sdf/spaceport.nvim`](https://github.com/CWood-sdf/spaceport.nvim)
+
+Install this repo with the slug below. Use `'CWood-sdf/spaceport.nvim'` if you want the upstream plugin instead. The screenshot under [Usage](#usage) is hosted on the upstream repo so it stays valid on this fork.
+
 ## Why
 
 I got really annoyed with the pattern of cd'ing to a project folder then doing `nvim .` then starting to program. I wanted to just type `nvim` and then a few keystrokes later, be in a project. I wanted something that was kind of like [harpoon](https://github.com/ThePrimeagen/harpoon), but for directories, not files.
@@ -26,7 +30,7 @@ lazy.nvim
 
 ```lua
 {
-    'CWood-sdf/spaceport.nvim',
+    'mhgit/spaceport-sdf',
     opts = {
 
     },
@@ -167,7 +171,7 @@ sections = {
 },
 ```
 
-This allows you to override every property detailed [below](https://github.com/CWood-sdf/spaceport.nvim#custom-screens) EXCEPT `lines`.
+This allows you to override every property detailed [below](https://github.com/mhgit/spaceport-sdf#custom-screens) EXCEPT `lines`.
 
 Overriding remaps is a slight bit different from the rest of the properties. If you would like to override a remap, do this:
 
@@ -381,11 +385,16 @@ require('telecope').extensions.spaceport.tmux_windows()
 require('telecope').extensions.spaceport.tmux_sessions()
 ```
 
-Or you can search for a directory that is not yet registered in spaceport:
+Or you can search for a directory that is not yet registered in spaceport (requires `fd`; tmux pickers require `tmux`):
 
 ```lua
 require('telescope').extensions.spaceport.find()
 ```
+
+## Healthchecks
+
+- `:checkhealth spaceport` — core plugin (setup, `projectHomes`, log path, sections, `curl` when `hacker_news` is enabled).
+- `:checkhealth telescope` — includes the `spaceport` extension (telescope, core, `fd`, `tmux`).
 
 ## Events
 
@@ -405,4 +414,17 @@ All other plugins use the `vim.v.oldfiles` to keep track of your most recently u
 
 ## Contributing
 
-Before contributing, it is suggested that you read the ARCHITECTURE.md file
+Before contributing, read [ARCHITECTURE.md](ARCHITECTURE.md).
+
+### Upstream pull requests
+
+Before opening a PR against **[CWood-sdf/spaceport.nvim](https://github.com/CWood-sdf/spaceport.nvim)**, revert fork-oriented documentation so upstream reviewers see their repo, not this fork:
+
+- **README.md** — Remove the fork banner at the top (upstream usually has none). Set the lazy.nvim slug back to `'CWood-sdf/spaceport.nvim'`. Change fork-specific links (for example the `#custom-screens` anchor) from `mhgit/spaceport-sdf` to `CWood-sdf/spaceport.nvim`. The Usage screenshot can keep pointing at upstream assets (this fork already uses that URL).
+- **doc/spaceport.txt** — Regenerate from README after those edits (push to `main` triggers panvimdoc in CI, or run panvimdoc locally).
+
+Quick audit:
+
+```bash
+rg 'mhgit/spaceport-sdf|CWood-sdf/spaceport.nvim' README.md doc/
+```

--- a/README.md
+++ b/README.md
@@ -380,9 +380,9 @@ require('telescope').extensions.spaceport.projects()
 Or you can search for a specific tmux window or session name:
 
 ```lua
-require('telecope').extensions.spaceport.tmux_windows()
+require('telescope').extensions.spaceport.tmux_windows()
 
-require('telecope').extensions.spaceport.tmux_sessions()
+require('telescope').extensions.spaceport.tmux_sessions()
 ```
 
 Or you can search for a directory that is not yet registered in spaceport (requires `fd`; tmux pickers require `tmux`):

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 The "blazingly fastest" way to get to your projects
 
-**Fork:** [`mhgit/spaceport-sdf`](https://github.com/mhgit/spaceport-sdf) · **Upstream:** [`CWood-sdf/spaceport.nvim`](https://github.com/CWood-sdf/spaceport.nvim)
-
-Install this repo with the slug below. Use `'CWood-sdf/spaceport.nvim'` if you want the upstream plugin instead. The screenshot under [Usage](#usage) is hosted on the upstream repo so it stays valid on this fork.
-
 ## Why
 
 I got really annoyed with the pattern of cd'ing to a project folder then doing `nvim .` then starting to program. I wanted to just type `nvim` and then a few keystrokes later, be in a project. I wanted something that was kind of like [harpoon](https://github.com/ThePrimeagen/harpoon), but for directories, not files.
@@ -30,7 +26,7 @@ lazy.nvim
 
 ```lua
 {
-    'mhgit/spaceport-sdf',
+    'CWood-sdf/spaceport.nvim',
     opts = {
 
     },
@@ -171,7 +167,7 @@ sections = {
 },
 ```
 
-This allows you to override every property detailed [below](https://github.com/mhgit/spaceport-sdf#custom-screens) EXCEPT `lines`.
+This allows you to override every property detailed [below](https://github.com/CWood-sdf/spaceport.nvim#custom-screens) EXCEPT `lines`.
 
 Overriding remaps is a slight bit different from the rest of the properties. If you would like to override a remap, do this:
 
@@ -387,6 +383,8 @@ require('telescope').extensions.spaceport.tmux_sessions()
 
 Or you can search for a directory that is not yet registered in spaceport (requires `fd`; tmux pickers require `tmux`):
 
+Config `projectHomes`: list of project folders the telescope find extension scans.
+
 ```lua
 require('telescope').extensions.spaceport.find()
 ```
@@ -415,16 +413,3 @@ All other plugins use the `vim.v.oldfiles` to keep track of your most recently u
 ## Contributing
 
 Before contributing, read [ARCHITECTURE.md](ARCHITECTURE.md).
-
-### Upstream pull requests
-
-Before opening a PR against **[CWood-sdf/spaceport.nvim](https://github.com/CWood-sdf/spaceport.nvim)**, revert fork-oriented documentation so upstream reviewers see their repo, not this fork:
-
-- **README.md** — Remove the fork banner at the top (upstream usually has none). Set the lazy.nvim slug back to `'CWood-sdf/spaceport.nvim'`. Change fork-specific links (for example the `#custom-screens` anchor) from `mhgit/spaceport-sdf` to `CWood-sdf/spaceport.nvim`. The Usage screenshot can keep pointing at upstream assets (this fork already uses that URL).
-- **doc/spaceport.txt** — Regenerate from README after those edits (push to `main` triggers panvimdoc in CI, or run panvimdoc locally).
-
-Quick audit:
-
-```bash
-rg 'mhgit/spaceport-sdf|CWood-sdf/spaceport.nvim' README.md doc/
-```

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ The default options are:
     -- What to do when entering a directory, personally I use "Oil .", but Ex is preinstalled with neovim
     projectEntry = "Ex",
 
+    -- Homes used by telescope.extensions.spaceport.find()
+    -- Spaceport scans these for exact `.git` directories using `fd`.
+    projectHomes = { "~" },
+    -- projectHomes = { "~/git-projects", "~/other-projects" },
+
     -- The farthest back in time that directories should be shown
     -- I personally use "yesterday" so that there aren't millions of directories on the screen.
     -- the possible values are: "pin", "today", "yesterday", "pastWeek", "pastMonth", and "later"
@@ -120,7 +125,7 @@ All the remaps are visible at the top of the screen with the default configurati
 When you are first starting out with spaceport, it has no history of which directories you have opened, there are 3 methods to add directories to the recents section:
 
 1. Open a directory by cd'ing to it and then running `nvim .` in your terminal
-2. Use telescope and run `require('telescope').extensions.spaceport.find()`, this will allow you to fuzzy find all subdirectories of the current directory and open them (using the linux `find` command)
+2. Use telescope and run `require('telescope').extensions.spaceport.find()`, this scans `projectHomes` for exact `.git` directories using `fd` and opens the parent project directory
 3. Run `:Spaceport importOldfiles` to import the files from `vim.v.oldfiles`, this option is not recommended because it will import files, not directories, and it will not import the time data, so all the files will be marked as being opened today
 
 This is what spaceport looks like when projects are tagged.

--- a/doc/spaceport.txt
+++ b/doc/spaceport.txt
@@ -475,9 +475,9 @@ name:
 Or you can search for a specific tmux window or session name:
 
 >lua
-    require('telecope').extensions.spaceport.tmux_windows()
-    
-    require('telecope').extensions.spaceport.tmux_sessions()
+require('telescope').extensions.spaceport.tmux_windows()
+
+require('telescope').extensions.spaceport.tmux_sessions()
 <
 
 Or you can search for a directory that is not yet registered in spaceport

--- a/doc/spaceport.txt
+++ b/doc/spaceport.txt
@@ -1,4 +1,5 @@
-*spaceport.txt*         For Neovim >= 0.8.0         Last change: 2026 March 29
+*spaceport.txt*
+                               For Neovim >= 0.8.0    Last change: 2026 May 09
 
 ==============================================================================
 Table of Contents                                *spaceport-table-of-contents*
@@ -14,6 +15,7 @@ Table of Contents                                *spaceport-table-of-contents*
   - Customization                     |spaceport-spaceport.nvim-customization|
   - Tmux Integration               |spaceport-spaceport.nvim-tmux-integration|
   - Telescope integration     |spaceport-spaceport.nvim-telescope-integration|
+  - Healthchecks                       |spaceport-spaceport.nvim-healthchecks|
   - Events                                   |spaceport-spaceport.nvim-events|
   - Spaceport Buffer Name     |spaceport-spaceport.nvim-spaceport-buffer-name|
   - Importing vim.v.oldfiles|spaceport-spaceport.nvim-importing-vim.v.oldfiles|
@@ -24,6 +26,14 @@ Table of Contents                                *spaceport-table-of-contents*
 1. Spaceport.nvim                                   *spaceport-spaceport.nvim*
 
 The "blazingly fastest" way to get to your projects
+
+**Fork:** `mhgit/spaceport-sdf` <https://github.com/mhgit/spaceport-sdf> ·
+**Upstream:** `CWood-sdf/spaceport.nvim`
+<https://github.com/CWood-sdf/spaceport.nvim>
+
+Install this repo with the slug below. Use `'CWood-sdf/spaceport.nvim'` if you
+want the upstream plugin instead. The screenshot under |spaceport-usage| is
+hosted on the upstream repo so it stays valid on this fork.
 
 
 WHY                                             *spaceport-spaceport.nvim-why*
@@ -67,7 +77,7 @@ lazy.nvim
 
 >lua
     {
-        'CWood-sdf/spaceport.nvim',
+        'mhgit/spaceport-sdf',
         opts = {
     
         },
@@ -97,6 +107,11 @@ The default options are:
     
         -- What to do when entering a directory, personally I use "Oil .", but Ex is preinstalled with neovim
         projectEntry = "Ex",
+    
+        -- Homes used by telescope.extensions.spaceport.find()
+        -- Spaceport scans these for exact `.git` directories using `fd`.
+        projectHomes = { "~" },
+        -- projectHomes = { "~/git-projects", "~/other-projects" },
     
         -- The farthest back in time that directories should be shown
         -- I personally use "yesterday" so that there aren't millions of directories on the screen.
@@ -176,7 +191,7 @@ directories you have opened, there are 3 methods to add directories to the
 recents section:
 
 1. Open a directory by cd’ing to it and then running `nvim .` in your terminal
-2. Use telescope and run `require('telescope').extensions.spaceport.find()`, this will allow you to fuzzy find all subdirectories of the current directory and open them (using the linux `find` command)
+2. Use telescope and run `require('telescope').extensions.spaceport.find()`, this scans `projectHomes` for exact `.git` directories using `fd` and opens the parent project directory
 3. Run `:Spaceport importOldfiles` to import the files from `vim.v.oldfiles`, this option is not recommended because it will import files, not directories, and it will not import the time data, so all the files will be marked as being opened today
 
 This is what spaceport looks like when projects are tagged.
@@ -222,7 +237,7 @@ example, if you wanted to set the title of a section to be different:
 <
 
 This allows you to override every property detailed below
-<https://github.com/CWood-sdf/spaceport.nvim#custom-screens> EXCEPT `lines`.
+<https://github.com/mhgit/spaceport-sdf#custom-screens> EXCEPT `lines`.
 
 Overriding remaps is a slight bit different from the rest of the properties. If
 you would like to override a remap, do this:
@@ -465,11 +480,18 @@ Or you can search for a specific tmux window or session name:
     require('telecope').extensions.spaceport.tmux_sessions()
 <
 
-Or you can search for a directory that is not yet registered in spaceport:
+Or you can search for a directory that is not yet registered in spaceport
+(requires `fd`; tmux pickers require `tmux`):
 
 >lua
     require('telescope').extensions.spaceport.find()
 <
+
+
+HEALTHCHECKS                           *spaceport-spaceport.nvim-healthchecks*
+
+- `:checkhealth spaceport` — core plugin (setup, `projectHomes`, log path, sections, `curl` when `hacker_news` is enabled).
+- `:checkhealth telescope` — includes the `spaceport` extension (telescope, core, `fd`, `tmux`).
 
 
 EVENTS                                       *spaceport-spaceport.nvim-events*
@@ -498,7 +520,22 @@ because `vim.v.oldfiles` does not provide time data.
 
 CONTRIBUTING                           *spaceport-spaceport.nvim-contributing*
 
-Before contributing, it is suggested that you read the ARCHITECTURE.md file
+Before contributing, read ARCHITECTURE.md <ARCHITECTURE.md>.
+
+
+UPSTREAM PULL REQUESTS ~
+
+Before opening a PR against **CWood-sdf/spaceport.nvim**, revert fork-oriented
+documentation so upstream reviewers see their repo, not this fork:
+
+- **README.md** — Remove the fork banner at the top (upstream usually has none). Set the lazy.nvim slug back to `'CWood-sdf/spaceport.nvim'`. Change fork-specific links (for example the `#custom-screens` anchor) from `mhgit/spaceport-sdf` to `CWood-sdf/spaceport.nvim`. The Usage screenshot can keep pointing at upstream assets (this fork already uses that URL).
+- **doc/spaceport.txt** — Regenerate from README after those edits (push to `main` triggers panvimdoc in CI, or run panvimdoc locally).
+
+Quick audit:
+
+>bash
+    rg 'mhgit/spaceport-sdf|CWood-sdf/spaceport.nvim' README.md doc/
+<
 
 ==============================================================================
 2. Links                                                     *spaceport-links*

--- a/doc/spaceport.txt
+++ b/doc/spaceport.txt
@@ -475,9 +475,9 @@ name:
 Or you can search for a specific tmux window or session name:
 
 >lua
-require('telescope').extensions.spaceport.tmux_windows()
-
-require('telescope').extensions.spaceport.tmux_sessions()
+    require('telescope').extensions.spaceport.tmux_windows()
+    
+    require('telescope').extensions.spaceport.tmux_sessions()
 <
 
 Or you can search for a directory that is not yet registered in spaceport

--- a/doc/spaceport.txt
+++ b/doc/spaceport.txt
@@ -1,5 +1,5 @@
 *spaceport.txt*
-                               For Neovim >= 0.8.0    Last change: 2026 May 09
+                               For Neovim >= 0.8.0    Last change: 2026 May 10
 
 ==============================================================================
 Table of Contents                                *spaceport-table-of-contents*
@@ -26,14 +26,6 @@ Table of Contents                                *spaceport-table-of-contents*
 1. Spaceport.nvim                                   *spaceport-spaceport.nvim*
 
 The "blazingly fastest" way to get to your projects
-
-**Fork:** `mhgit/spaceport-sdf` <https://github.com/mhgit/spaceport-sdf> ·
-**Upstream:** `CWood-sdf/spaceport.nvim`
-<https://github.com/CWood-sdf/spaceport.nvim>
-
-Install this repo with the slug below. Use `'CWood-sdf/spaceport.nvim'` if you
-want the upstream plugin instead. The screenshot under |spaceport-usage| is
-hosted on the upstream repo so it stays valid on this fork.
 
 
 WHY                                             *spaceport-spaceport.nvim-why*
@@ -77,7 +69,7 @@ lazy.nvim
 
 >lua
     {
-        'mhgit/spaceport-sdf',
+        'CWood-sdf/spaceport.nvim',
         opts = {
     
         },
@@ -237,7 +229,7 @@ example, if you wanted to set the title of a section to be different:
 <
 
 This allows you to override every property detailed below
-<https://github.com/mhgit/spaceport-sdf#custom-screens> EXCEPT `lines`.
+<https://github.com/CWood-sdf/spaceport.nvim#custom-screens> EXCEPT `lines`.
 
 Overriding remaps is a slight bit different from the rest of the properties. If
 you would like to override a remap, do this:
@@ -483,6 +475,9 @@ Or you can search for a specific tmux window or session name:
 Or you can search for a directory that is not yet registered in spaceport
 (requires `fd`; tmux pickers require `tmux`):
 
+Config `projectHomes`: list of project folders the telescope find extension
+scans.
+
 >lua
     require('telescope').extensions.spaceport.find()
 <
@@ -521,21 +516,6 @@ because `vim.v.oldfiles` does not provide time data.
 CONTRIBUTING                           *spaceport-spaceport.nvim-contributing*
 
 Before contributing, read ARCHITECTURE.md <ARCHITECTURE.md>.
-
-
-UPSTREAM PULL REQUESTS ~
-
-Before opening a PR against **CWood-sdf/spaceport.nvim**, revert fork-oriented
-documentation so upstream reviewers see their repo, not this fork:
-
-- **README.md** — Remove the fork banner at the top (upstream usually has none). Set the lazy.nvim slug back to `'CWood-sdf/spaceport.nvim'`. Change fork-specific links (for example the `#custom-screens` anchor) from `mhgit/spaceport-sdf` to `CWood-sdf/spaceport.nvim`. The Usage screenshot can keep pointing at upstream assets (this fork already uses that URL).
-- **doc/spaceport.txt** — Regenerate from README after those edits (push to `main` triggers panvimdoc in CI, or run panvimdoc locally).
-
-Quick audit:
-
->bash
-    rg 'mhgit/spaceport-sdf|CWood-sdf/spaceport.nvim' README.md doc/
-<
 
 ==============================================================================
 2. Links                                                     *spaceport-links*

--- a/doc/tags
+++ b/doc/tags
@@ -4,6 +4,7 @@ spaceport-spaceport.nvim-contributing	spaceport.txt	/*spaceport-spaceport.nvim-c
 spaceport-spaceport.nvim-customization	spaceport.txt	/*spaceport-spaceport.nvim-customization*
 spaceport-spaceport.nvim-defaults	spaceport.txt	/*spaceport-spaceport.nvim-defaults*
 spaceport-spaceport.nvim-events	spaceport.txt	/*spaceport-spaceport.nvim-events*
+spaceport-spaceport.nvim-healthchecks	spaceport.txt	/*spaceport-spaceport.nvim-healthchecks*
 spaceport-spaceport.nvim-how	spaceport.txt	/*spaceport-spaceport.nvim-how*
 spaceport-spaceport.nvim-importing-vim.v.oldfiles	spaceport.txt	/*spaceport-spaceport.nvim-importing-vim.v.oldfiles*
 spaceport-spaceport.nvim-installation	spaceport.txt	/*spaceport-spaceport.nvim-installation*

--- a/lua/spaceport/health.lua
+++ b/lua/spaceport/health.lua
@@ -1,0 +1,120 @@
+local M = {}
+
+local h = vim.health
+
+local function start(name)
+    (h.start or h.report_start)(name)
+end
+
+local function ok(msg)
+    (h.ok or h.report_ok)(msg)
+end
+
+---@param msg string
+---@param advice? string[]
+local function warn(msg, advice)
+    local fn = h.warn or h.report_warn
+    if advice and #advice > 0 and not h.warn then
+        fn(msg .. "\n  - " .. table.concat(advice, "\n  - "))
+        return
+    end
+    if advice and #advice > 0 then
+        fn(msg, advice)
+        return
+    end
+    fn(msg)
+end
+
+---@param msg string
+---@param advice? string[]
+local function err(msg, advice)
+    local fn = h.error or h.report_error
+    if advice and #advice > 0 and not h.error then
+        fn(msg .. "\n  - " .. table.concat(advice, "\n  - "))
+        return
+    end
+    if advice and #advice > 0 then
+        fn(msg, advice)
+        return
+    end
+    fn(msg)
+end
+
+function M.check()
+    start("spaceport: core")
+
+    if vim.fn.has("nvim-0.8") == 1 then
+        ok("Neovim >= 0.8.0")
+    else
+        err("Neovim >= 0.8.0 required")
+    end
+
+    local sp = require("spaceport")
+    if sp._getHasInit() then
+        ok("setup() has been called")
+    else
+        warn(
+            "setup() has not been called",
+            { "Call require('spaceport').setup({...}) in your config" }
+        )
+    end
+
+    start("spaceport: projectHomes")
+    for _, home in ipairs(sp._getProjectHomes()) do
+        if vim.fn.isdirectory(home) == 1 then
+            ok(("%s exists"):format(home))
+        else
+            warn(
+                ("%s is not a directory"):format(home),
+                { "Remove or fix this entry in projectHomes; .find() will skip it" }
+            )
+        end
+    end
+
+    start("spaceport: log")
+    local cfg = sp.getConfig()
+    local parent = vim.fn.fnamemodify(cfg.logPath, ":h")
+    --- filewritable: 2 writable, 1 missing but parent allows create, 0 not writable
+    local fw = vim.fn.filewritable(parent)
+    if fw == 2 or fw == 1 then
+        ok(("log directory writable or creatable: %s"):format(parent))
+    else
+        warn(
+            ("log directory not writable: %s"):format(parent),
+            { "Set logPath to a writable location" }
+        )
+    end
+
+    start("spaceport: sections")
+    local known = {
+        name = true,
+        remaps = true,
+        recents = true,
+        _global_remaps = true,
+        hacker_news = true,
+    }
+    local uses_hn = false
+    for _, s in ipairs(sp._getSections()) do
+        local n = type(s) == "table" and s[1] or s
+        if type(n) == "string" and known[n] ~= true then
+            warn(
+                ("unknown section %q"):format(n),
+                {
+                    "Built-ins: name, remaps, recents, _global_remaps, hacker_news",
+                }
+            )
+        end
+        if n == "hacker_news" then
+            uses_hn = true
+        end
+    end
+    if uses_hn then
+        if vim.fn.executable("curl") == 1 then
+            ok("curl found (used by hacker_news)")
+        else
+            warn("curl not found", { "Required by the hacker_news section" })
+        end
+    end
+end
+
+return M

--- a/lua/spaceport/init.lua
+++ b/lua/spaceport/init.lua
@@ -24,6 +24,7 @@ local M = {}
 ---@field lastViewTime "pin"|"today"|"yesterday"|"pastWeek"|"pastMonth"|"later"
 ---@field debug boolean
 ---@field shortcuts string[][]
+---@field projectHomes string[]
 local opts = {
     lastViewTime = "later",
     replaceDirs = {},
@@ -42,6 +43,7 @@ local opts = {
     maxRecentFiles = vim.api.nvim_win_get_height(0),
     debug = false,
     shortcuts = {},
+    projectHomes = { "~" },
 }
 
 local lastClean = 0
@@ -82,6 +84,40 @@ function M.getStartupTime()
 end
 
 local hasInit = false
+
+---@param path string
+---@return string
+local function expandPath(path)
+    if path == "" then
+        return path
+    end
+    local expanded = vim.fn.expand(path)
+    return vim.fn.fnamemodify(expanded, ":p")
+end
+
+---@param homes string[]|string
+---@return string[]
+local function normalizeProjectHomes(homes)
+    local ret = {}
+    local seen = {}
+    if type(homes) == "string" then
+        homes = { homes }
+    end
+    for _, home in ipairs(homes or {}) do
+        if type(home) == "string" then
+            local normalized = expandPath(home)
+            if normalized ~= "" and not seen[normalized] then
+                seen[normalized] = true
+                table.insert(ret, normalized)
+            end
+        end
+    end
+    if #ret == 0 then
+        table.insert(ret, expandPath("~"))
+    end
+    return ret
+end
+
 ---@param _opts SpaceportConfig
 function M.setup(_opts)
     hasInit = true
@@ -91,6 +127,7 @@ function M.setup(_opts)
         end
         opts[k] = v
     end
+    opts.projectHomes = normalizeProjectHomes(opts.projectHomes)
     opts.logPath = vim.fn.fnamemodify(opts.logPath, ":p") or ""
     require("spaceport.setup_auto")
     vim.schedule(function ()
@@ -131,6 +168,12 @@ end
 ---@return (string|string[])[]
 function M._getIgnoreDirs()
     return opts.replaceDirs
+end
+
+---@return string[]
+function M._getProjectHomes()
+    opts.projectHomes = normalizeProjectHomes(opts.projectHomes)
+    return opts.projectHomes
 end
 
 ---@return string

--- a/lua/spaceport/utils.lua
+++ b/lua/spaceport/utils.lua
@@ -1,4 +1,35 @@
 local M = {}
+
+--- Resolved GitHub-style slug like owner/repo from git remote, else plugin folder name.
+---@return string
+function M.plugin_install_hint()
+    local paths = vim.api.nvim_get_runtime_file("lua/spaceport/init.lua", false)
+    if not paths or #paths == 0 then
+        return "spaceport.nvim"
+    end
+    local root = vim.fn.fnamemodify(paths[1], ":p:h:h:h")
+    local url = vim.trim(vim.fn.system({
+        "git",
+        "-C",
+        root,
+        "remote",
+        "get-url",
+        "origin",
+    }))
+    if vim.v.shell_error == 0 and url ~= "" then
+        local owner, repo = url:match("github%.com[:/]([^/]+)/([^%s/]+)")
+        if owner and repo then
+            repo = repo:gsub("%.git$", "")
+            return owner .. "/" .. repo
+        end
+    end
+    local name = vim.fn.fnamemodify(root, ":t")
+    if name ~= "" and name ~= "." then
+        return name
+    end
+    return "spaceport.nvim"
+end
+
 ---@return number
 function M.getSeconds()
     return vim.fn.localtime()

--- a/lua/spaceport/utils.lua
+++ b/lua/spaceport/utils.lua
@@ -1,35 +1,5 @@
 local M = {}
 
---- Resolved GitHub-style slug like owner/repo from git remote, else plugin folder name.
----@return string
-function M.plugin_install_hint()
-    local paths = vim.api.nvim_get_runtime_file("lua/spaceport/init.lua", false)
-    if not paths or #paths == 0 then
-        return "spaceport.nvim"
-    end
-    local root = vim.fn.fnamemodify(paths[1], ":p:h:h:h")
-    local url = vim.trim(vim.fn.system({
-        "git",
-        "-C",
-        root,
-        "remote",
-        "get-url",
-        "origin",
-    }))
-    if vim.v.shell_error == 0 and url ~= "" then
-        local owner, repo = url:match("github%.com[:/]([^/]+)/([^%s/]+)")
-        if owner and repo then
-            repo = repo:gsub("%.git$", "")
-            return owner .. "/" .. repo
-        end
-    end
-    local name = vim.fn.fnamemodify(root, ":t")
-    if name ~= "" and name ~= "." then
-        return name
-    end
-    return "spaceport.nvim"
-end
-
 ---@return number
 function M.getSeconds()
     return vim.fn.localtime()

--- a/lua/telescope/_extensions/spaceport.lua
+++ b/lua/telescope/_extensions/spaceport.lua
@@ -1,5 +1,93 @@
 local telescope = require("telescope")
 
+local function check()
+    local health = vim.health
+    local start = health.start or health.report_start
+    local ok = health.ok or health.report_ok
+
+    ---@param msg string
+    ---@param advice? string[]
+    local function warn(msg, advice)
+        local fn = health.warn or health.report_warn
+        if advice and #advice > 0 and not health.warn then
+            fn(msg .. "\n  - " .. table.concat(advice, "\n  - "))
+            return
+        end
+        if advice and #advice > 0 then
+            fn(msg, advice)
+            return
+        end
+        fn(msg)
+    end
+
+    ---@param msg string
+    ---@param advice? string[]
+    local function err(msg, advice)
+        local fn = health.error or health.report_error
+        if advice and #advice > 0 and not health.error then
+            fn(msg .. "\n  - " .. table.concat(advice, "\n  - "))
+            return
+        end
+        if advice and #advice > 0 then
+            fn(msg, advice)
+            return
+        end
+        fn(msg)
+    end
+
+    start("telescope-spaceport")
+
+    local has_telescope = pcall(require, "telescope")
+    if has_telescope then
+        ok("telescope loaded")
+    else
+        err("telescope not found")
+    end
+
+    local has_core = pcall(require, "spaceport")
+    if has_core then
+        ok("spaceport core loaded")
+    else
+        local hint = "spaceport.nvim"
+        do
+            local ok_util, utils = pcall(require, "spaceport.utils")
+            if ok_util and type(utils.plugin_install_hint) == "function" then
+                hint = utils.plugin_install_hint()
+            end
+        end
+        err(
+            "spaceport core not loaded",
+            {
+                ("Install the spaceport plugin (%s) and call require('spaceport').setup({})"):format(
+                    hint
+                ),
+            }
+        )
+    end
+
+    if vim.fn.executable("fd") == 1 then
+        ok("fd found (used by .find())")
+    else
+        warn(
+            "fd not found",
+            {
+                "Install sharkdp/fd; required by telescope.extensions.spaceport.find()",
+            }
+        )
+    end
+
+    if vim.fn.executable("tmux") == 1 then
+        ok("tmux found")
+    else
+        warn(
+            "tmux not found",
+            {
+                "Optional; needed only for .tmux_windows() / .tmux_sessions()",
+            }
+        )
+    end
+end
+
 return telescope.register_extension({
     exports = {
         projects = require("telescope._extensions.spaceport_mru"),
@@ -7,4 +95,5 @@ return telescope.register_extension({
         tmux_sessions = require("telescope._extensions.spaceport_tmux_sessions"),
         find = require("telescope._extensions.spaceport_finder"),
     },
+    health = check,
 })

--- a/lua/telescope/_extensions/spaceport.lua
+++ b/lua/telescope/_extensions/spaceport.lua
@@ -48,19 +48,10 @@ local function check()
     if has_core then
         ok("spaceport core loaded")
     else
-        local hint = "spaceport.nvim"
-        do
-            local ok_util, utils = pcall(require, "spaceport.utils")
-            if ok_util and type(utils.plugin_install_hint) == "function" then
-                hint = utils.plugin_install_hint()
-            end
-        end
         err(
             "spaceport core not loaded",
             {
-                ("Install the spaceport plugin (%s) and call require('spaceport').setup({})"):format(
-                    hint
-                ),
+                "Install the spaceport plugin (spaceport.nvim) and call require('spaceport').setup({})",
             }
         )
     end

--- a/lua/telescope/_extensions/spaceport_finder.lua
+++ b/lua/telescope/_extensions/spaceport_finder.lua
@@ -4,19 +4,53 @@ local conf = require("telescope.config").values
 local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
 
+---@param gitDir string
+---@return string
+local function toProjectDir(gitDir)
+    local normalized = gitDir:gsub("/+$", "")
+    if normalized:sub(-5) == "/.git" then
+        return normalized:sub(1, -6)
+    end
+    return vim.fn.fnamemodify(normalized, ":h")
+end
+
 return function (opts)
     opts = opts or require("telescope.themes").get_dropdown({})
+    local projectHomes = require("spaceport")._getProjectHomes()
+    local cmd = {
+        "fd",
+        "--type", "d",
+        "--hidden",
+        "--no-follow",
+        "--absolute-path",
+        "--regex", "^\\.git$",
+    }
+    for _, home in ipairs(projectHomes) do
+        table.insert(cmd, home)
+    end
+
+    local fdMatches = vim.fn.systemlist(cmd)
+    if vim.v.shell_error ~= 0 then
+        require("spaceport").log("spaceport.find failed to run fd")
+        return
+    end
+
+    local seen = {}
+    local projects = {}
+    for _, gitDir in ipairs(fdMatches) do
+        local projectDir = toProjectDir(gitDir)
+        if not seen[projectDir] then
+            seen[projectDir] = true
+            table.insert(projects, projectDir)
+        end
+    end
+
     pickers
         .new(opts, {
             prompt_title = "Find Spaceport Directory",
-            finder = finders.new_oneshot_job({ "find" }, {
+            finder = finders.new_table({
+                results = projects,
                 entry_maker = function (entry)
-                    if entry:gsub(".git", "") ~= entry then
-                        return nil
-                    end
-                    if entry:sub(1, 1) == "." then
-                        entry = vim.loop.cwd() .. entry:sub(2)
-                    end
                     return {
                         value = entry,
                         display = require("spaceport")._fixDir(entry),


### PR DESCRIPTION
**Summary**

Closes #8 (https://github.com/CWood-sdf/spaceport.nvim/issues/8).

Adds `projectHomes` and rewrites `telescope.extensions.spaceport.find()` to scan those directories with `fd` for real `.git` project roots (replacing the previous `cwd` + `find` behaviour described in that issue). Adds `:checkhealth spaceport` and a `telescope-spaceport` health section (setup, `projectHomes`, log path, sections, `fd`, `tmux`, `curl`). Documents the new behaviour and healthchecks in the README and vimdoc; fixes a `telecope` → `telescope` typo.

**Changes**

- **A. projectHomes + telescope finder via fd** — `lua/spaceport/init.lua` (field, normaliser, accessor), `lua/spaceport/utils.lua` (`plugin_install_hint` for healthcheck), `lua/telescope/_extensions/spaceport_finder.lua` (fd-based scan, dedup, parent-dir derivation).
- **B. Healthchecks** — `lua/spaceport/health.lua` (new), `lua/telescope/_extensions/spaceport.lua` (registers `health = check`).
- **C. Docs** — `README.md` (`projectHomes`, `## Healthchecks`, fd/tmux note, Contributing / ARCHITECTURE link as applicable).
- **D. Auto-generated vimdoc** — `doc/spaceport.txt`, `doc/tags`.
- **E. Typo** — `README.md`, `doc/spaceport.txt` (`telecope` → `telescope`).

**Manual tests**

- `icons = true` / `false` / custom table — glyph rendering and `:Spaceport refresh` behaviour OK; `icons = "yes"` handled as a negative case.
- `shortcuts` targeting `~/.local/share/chezmoi` — jump, `projectEntry`, and `SpaceportDone` verified; coexistence with another shortcut and Lua pattern edge cases OK.
- `:checkhealth spaceport` and `:checkhealth telescope` both clean where `fd`, `tmux`, and `curl` are present.

**Notes for upstream**

`telescope.extensions.spaceport.find()` now requires `fd` and scans `projectHomes` instead of fuzzy-finding under `cwd` via `find`. README and `:checkhealth telescope` call this out.
